### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/easytocloud/Mac-letterhead/security/code-scanning/1](https://github.com/easytocloud/Mac-letterhead/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` so the workflow documents and enforces least privilege.  
Best fix here: set workflow-level permissions to read-only for repository contents (`contents: read`), which is sufficient for `actions/checkout` and running tests, and does not change intended functionality.

Change location:
- File: `.github/workflows/ci.yml`
- Insert immediately after the workflow triggers (`on: ...`) and before `concurrency:`.

No imports, methods, or dependencies are needed—this is a YAML configuration-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
